### PR TITLE
Increase edgechromium blob results to allow current versions

### DIFF
--- a/src/webdrivermanager/edgechromium.py
+++ b/src/webdrivermanager/edgechromium.py
@@ -11,7 +11,7 @@ class EdgeChromiumDriverManager(WebDriverManagerBase):
     """Class for downloading Edge Chromium WebDriver."""
 
     edgechromium_driver_base_url = (
-        "https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver?maxresults=1000&comp=list&timeout=60000"
+        "https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver?maxresults=5000&comp=list&timeout=60000"
     )
     _drivers = None
     _versions = None


### PR DESCRIPTION
Increase max results to 5000 as the current limit of 1000 skips out on latest versions
#70 