### PR TITLE
Added option to dynamically generate gecko driver mappings

### DIFF
--- a/src/webdrivermanager/base.py
+++ b/src/webdrivermanager/base.py
@@ -383,3 +383,20 @@ class WebDriverManagerBase:
         except Exception as e:
             LOGGER.warning(f"Unable to change permissions of {dest_file}.\n{e}")
         return (src_file, dest_file)
+
+
+    def _get_gecko_mappings():
+        URL = 'https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html'
+        page = requests.get( URL )
+        soup = BeautifulSoup( page.content , 'lxml')
+
+        table = soup.find("div", {"id": "supported-platforms"}).find("table")
+        rows = table.find_all('tr')
+        version_map = []
+        for row in rows:
+            cols=row.find_all('td')
+            if len(cols) > 0:
+                cols=[x.text.strip() for x in cols ]
+                version_map.append((cols[0], cols[2].split(" ")[0]))
+
+        return version_map

--- a/src/webdrivermanager/gecko.py
+++ b/src/webdrivermanager/gecko.py
@@ -69,7 +69,8 @@ class GeckoDriverManager(WebDriverManagerBase):
         # Map browser version to webdriver version
         # https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
         browser_version = self._get_browser_version()
-        version_map = [(60, "v0.29.0"), (57, "v0.25.0"), (55, "v0.20.1"), (53, "v0.18.0"), (52, "v0.17.0")]
+        # version_map = [(60, "v0.29.0"), (57, "v0.25.0"), (55, "v0.20.1"), (53, "v0.18.0"), (52, "v0.17.0")]
+        version_map = self._get_gecko_mappings()
 
         for browser_minimum, driver_version in version_map:
             if browser_version >= browser_minimum:


### PR DESCRIPTION
If there is new update to gecko drivers, no need to manually maintain the mappings. This PR will scrape the "https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html" and get the latest mappings.

Let me know if this can be merged.