### PR TITLE
- Fixed firefox detection on a Mac with M1 chip

### DIFF
--- a/src/webdrivermanager/base.py
+++ b/src/webdrivermanager/base.py
@@ -188,9 +188,9 @@ class WebDriverManagerBase:
         if len(filename) > 1:
             if self.os_name == "mac":
                 filename = (
-                    [name for name in filenames if "aarch64" in name]
-                    if mac_cpu_type == "arm"
-                    else [name for name in filenames if "aarch64" not in name]
+                    [name for name in filenames if "aarch64" in name and "macos" in name]
+                    if mac_cpu_type == "arm" or mac_cpu_type == "m1"
+                    else [name for name in filenames if "aarch64" not in name and "macos" in name]
                 )
             else:
                 filename = [name for name in filenames if self.os_name + self.bitness in name and not name.endswith(".asc")]


### PR DESCRIPTION
Fixed right driver to download for latest Firefox on a Mac Book Pro with M1 chip.
Filtered out also the "linux" names from the release, that was wrongly not filtering by "macos".
Thx! L